### PR TITLE
Improved arguments count check error message, closes #16

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,4 +5,3 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = tab
 trim_trailing_whitespace = true
-insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 *.log.*
 *.log
 *.tgz
+
+test/auto-top.gypi
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ dist/
 *.log
 *.tgz
 
-test/auto-top.gypi
+auto*.gypi
 

--- a/include/nbind/signature/BaseSignature.h
+++ b/include/nbind/signature/BaseSignature.h
@@ -178,7 +178,10 @@ public:
 
 		if(!arityIsValid(nanArgs)) {
 			// TODO: When function is overloaded, this test could be skipped...
-			Nan::ThrowError("Wrong number of arguments");
+
+			char buffer [40];
+			sprintf (buffer, "Wrong number of arguments, expected %d", (sizeof...(Args)));
+			Nan::ThrowError(buffer);
 			return;
 		}
 

--- a/include/nbind/signature/BaseSignature.h
+++ b/include/nbind/signature/BaseSignature.h
@@ -179,9 +179,8 @@ public:
 		if(!arityIsValid(nanArgs)) {
 			// TODO: When function is overloaded, this test could be skipped...
 
-			char buffer [40];
-			sprintf (buffer, "Wrong number of arguments, expected %d", (sizeof...(Args)));
-			Nan::ThrowError(buffer);
+			std::string msg = "Wrong number of arguments, expected " + std::to_string(sizeof...(Args));
+			Nan::ThrowError(msg.c_str());
 			return;
 		}
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,0 @@
-node_modules/
-auto.gypi

--- a/test/test.js
+++ b/test/test.js
@@ -202,3 +202,17 @@ test('Arrays', function(t) {
 
 	t.end();
 });
+
+
+test('Arguments checks', function(t) {
+	t.throws(
+		function() {
+			testModule.PrimitiveMethods.incrementIntStatic(42, null);
+		},
+		new Error('Wrong number of arguments, expected 1')
+	);
+
+	t.end();
+});
+
+


### PR DESCRIPTION
As discussed in #16.

I also add a test to check the error message, I didn't find the one you mentioned in the issue, all tests are still passing after I changed the message format.

In the others two commit, I add a file created by tests to .gitignore, and a .editorconfig file to help my editor with code formatting. I will revert this changes if you don't like them...

I didn't change the error message for the overloaded functions, I should have changed them with something like `... expected 2 or 4 or 5` , but it seems weird to me.
