### PR TITLE
Fix C source files compilation

### DIFF
--- a/src/nbind-common.gypi
+++ b/src/nbind-common.gypi
@@ -5,6 +5,7 @@
 	"conditions": [
 		["asmjs==1", {
 			"make_global_settings": [
+				["CC",  "<!(npm run -s emcc-path)"],
 				["CXX",  "<!(npm run -s emcc-path)"],
 				["LINK", "<!(npm run -s emcc-path)"],
 			]

--- a/src/nbind.gypi
+++ b/src/nbind.gypi
@@ -30,8 +30,6 @@
 
 			"cflags": [
 				"-O3",
-				"-std=c++11",
-				"-fno-exceptions",
 				"--pre-js", "<(_prejs_path)",
 				"--post-js", "<(_postjs_path)",
 				"--js-library", "<(_jslib_path)",
@@ -39,6 +37,11 @@
 				"-s", "EXPORTED_FUNCTIONS=[\"_nbind_init\",\"_nbind_value\"]",
 				"-s", "DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[\"nbind_value\",\"\\$$Browser\"]"
 			],
+
+                        "cflags_cc": [
+				"-std=c++11",
+				"-fno-exceptions",
+                        ],
 
 			"xcode_settings": {
 				"GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
@@ -53,8 +56,11 @@
 				"v8/Binding.cc"
 			],
 
+                        "cflags": [
+				"-O3"
+                        ],
+
 			"cflags_cc": [
-				"-O3",
 				"-std=c++11",
 				"-fexceptions"
 			],

--- a/src/todts.ts
+++ b/src/todts.ts
@@ -160,7 +160,7 @@ export function dump(reflect: Reflect) {
 
 			classCodeList.push(
 				'export interface ' + superClass + ' extends ' + bindClass.superList.map(
-					(superClass: BindClass) => superClass.name
+					(superClassEntry: BindClass) => superClassEntry.name
 				).join(', ') + ' {}\n' +
 				'export var ' + superClass + ': { new(): ' + superClass + ' };'
 			);


### PR DESCRIPTION
The current flags break C compilation when building with `--asmjs`, because emscripten doesn't understand why C++-specific flags are used with the C compiler. This commit fix this by splitted the flags as `cflags` and `cflags_cc`.