### PR TITLE
Fix duplicate 'cflags_cc' entry

### DIFF
--- a/src/nbind.gypi
+++ b/src/nbind.gypi
@@ -20,8 +20,6 @@
 			"product_name": "nbind.js",
 			"type":         "executable",
 			"sources":    [ "em/Binding.cc" ],
-			"cflags_cc":  [ "<@(_cflags)" ],
-			"ldflags":    [ "<@(_cflags)" ],
 
 			"copies": [{"destination": "<(INTERMEDIATE_DIR)", "files": ["pre.js", "post.js", "../dist/em-api.js"]}],
 			"prejs_path": "<(INTERMEDIATE_DIR)/pre.js",
@@ -29,6 +27,7 @@
 			"jslib_path": "<(INTERMEDIATE_DIR)/em-api.js",
 
 			"cflags": [
+                                "<@(_cflags)",
 				"-O3",
 				"--pre-js", "<(_prejs_path)",
 				"--post-js", "<(_postjs_path)",
@@ -40,7 +39,11 @@
 
                         "cflags_cc": [
 				"-std=c++11",
-				"-fno-exceptions",
+				"-fno-exceptions"
+                        ],
+
+			"ldflags": [
+                                "<@(_cflags)"
                         ],
 
 			"xcode_settings": {


### PR DESCRIPTION
My previous PR worked fine on my system but was apparently buggy because of a dual `cflags_cc` property that I failed to identify; this PR should fix this (and a trailing comma).