### PR TITLE
Fix empty constructor case

### DIFF
--- a/include/nbind/v8/Overloader.h
+++ b/include/nbind/v8/Overloader.h
@@ -115,7 +115,7 @@ public:
 		v8::Local<v8::Function> constructor = def.constructorJS->GetFunction();
 
 		// Call the JavaScript constructor with the new operator.
-		auto result = (argc)?(Nan::NewInstance(constructor, argc, &argv[0])):(Nan::NewInstance(constructor, argc, nullptr));
+		auto result = Nan::NewInstance(constructor, argc, (argc)?(&argv[0]):(nullptr));
 
 		if(result.IsEmpty()) args.GetReturnValue().Set(Nan::Undefined());
 		else args.GetReturnValue().Set(result.ToLocalChecked());

--- a/include/nbind/v8/Overloader.h
+++ b/include/nbind/v8/Overloader.h
@@ -115,7 +115,7 @@ public:
 		v8::Local<v8::Function> constructor = def.constructorJS->GetFunction();
 
 		// Call the JavaScript constructor with the new operator.
-		auto result = Nan::NewInstance(constructor, argc, &argv[0]);
+		auto result = (argc)?(Nan::NewInstance(constructor, argc, &argv[0])):(Nan::NewInstance(constructor, argc, nullptr));
 
 		if(result.IsEmpty()) args.GetReturnValue().Set(Nan::Undefined());
 		else args.GetReturnValue().Set(result.ToLocalChecked());


### PR DESCRIPTION
This issue manifests itself when building in Debug on Windows. When the input constructor has no arguments, the vector is empty. Taking a pointer to the (non-existent) first element is invalid in this case, but is only caught in debug mode due to additional runtime checks. 