### PR TITLE
Enable RTTI for non-Asm.js builds

### DIFF
--- a/src/nbind.gypi
+++ b/src/nbind.gypi
@@ -80,6 +80,10 @@
 				}
 			},
 
+			"defines": [
+				"_HAS_EXCEPTIONS=1"
+			],
+
 			"xcode_settings": {
 				"GCC_ENABLE_CPP_RTTI": "YES",
 				"GCC_ENABLE_CPP_EXCEPTIONS": "YES",

--- a/src/nbind.gypi
+++ b/src/nbind.gypi
@@ -68,6 +68,10 @@
 				"-fexceptions"
 			],
 
+			"cflags_cc!": [
+				"-fno-rtti"
+			],
+
 			"msbuild_settings": {
 				"ClCompile": {
 					"RuntimeTypeInfo": "false",
@@ -77,6 +81,7 @@
 			},
 
 			"xcode_settings": {
+				"GCC_ENABLE_CPP_RTTI": "YES",
 				"GCC_ENABLE_CPP_EXCEPTIONS": "YES",
 				"CLANG_CXX_LANGUAGE_STANDARD": "c++11",
 				"MACOSX_DEPLOYMENT_TARGET": "10.7",


### PR DESCRIPTION
By default -fno-rtti was being set on builds which broke exception handling.