### PR TITLE
Support node 12

### DIFF
--- a/include/nbind/v8/ArgFromWire.h
+++ b/include/nbind/v8/ArgFromWire.h
@@ -34,7 +34,7 @@ template<typename PolicyList, size_t Index>
 struct ArgFromWire<PolicyList, Index, const char *> {
 
 	template <typename NanArgs>
-	ArgFromWire(const NanArgs &args) : val(args[Index]->ToString()) {}
+	ArgFromWire(const NanArgs &args) : val(Nan::To<v8::String>(args[Index]).ToLocalChecked()) {}
 
 	template <typename NanArgs>
 	inline const char *get(const NanArgs &args) {
@@ -53,7 +53,7 @@ template<typename PolicyList, size_t Index>
 struct ArgFromWire<PolicyList, Index, const unsigned char *> {
 
 	template <typename NanArgs>
-	ArgFromWire(const NanArgs &args) : val(args[Index]->ToString()) {}
+	ArgFromWire(const NanArgs &args) : val(Nan::To<v8::String>(args[Index]).ToLocalChecked()) {}
 
 	template <typename NanArgs>
 	inline const unsigned char *get(const NanArgs &args) {

--- a/include/nbind/v8/BindWrapper.h
+++ b/include/nbind/v8/BindWrapper.h
@@ -213,7 +213,7 @@ public:
 	}
 
 	static void wrapPtr(const Nan::FunctionCallbackInfo<v8::Value> &nanArgs) {
-		auto flags = static_cast<TypeFlags>(nanArgs[1]->Uint32Value());
+		auto flags = static_cast<TypeFlags>(Nan::To<unsigned int>(nanArgs[1]).FromJust());
 		void *ptr = v8::Handle<v8::External>::Cast(nanArgs[0])->Value();
 
 		if((flags & TypeFlags::refMask) == TypeFlags::isSharedPtr) {

--- a/include/nbind/v8/BindingStd.h
+++ b/include/nbind/v8/BindingStd.h
@@ -125,7 +125,7 @@ template <> struct BindingType<std::string> {
 	}
 
 	static inline Type fromWireType(WireType arg) {
-		Nan::Utf8String val(arg->ToString());
+		Nan::Utf8String val(Nan::To<v8::String>(arg).ToLocalChecked());
 		return(std::string(*val, val.length()));
 	}
 
@@ -164,7 +164,7 @@ struct ArgFromWire<PolicyList, Index, const std::string &> {
 
 	// TODO: Get string length from JS to support zero bytes?
 	template <typename NanArgs>
-	ArgFromWire(const NanArgs &args) : val(*Nan::Utf8String(args[Index]->ToString())) {}
+	ArgFromWire(const NanArgs &args) : val(*Nan::Utf8String(Nan::To<v8::String>(args[Index]).ToLocalChecked())) {}
 
 	template <typename NanArgs>
 	inline const std::string &get(const NanArgs &args) {

--- a/include/nbind/v8/BindingType.h
+++ b/include/nbind/v8/BindingType.h
@@ -49,7 +49,7 @@ struct BindingType<ArgType *> {
 
 	static inline Type fromWireType(WireType arg) {
 		return(BindWrapper<BaseType>::getBound(
-			arg->ToObject(),
+			Nan::To<v8::Object>(arg).ToLocalChecked(),
 			std::is_const<ArgType>::value ?
 				TypeFlags::isConst :
 				TypeFlags::none
@@ -93,7 +93,7 @@ struct BindingType<std::shared_ptr<ArgType>> {
 
 	static inline Type fromWireType(WireType arg) {
 		return(BindWrapper<BaseType>::getShared(
-			arg->ToObject(),
+			Nan::To<v8::Object>(arg).ToLocalChecked(),
 			std::is_const<ArgType>::value ?
 				TypeFlags::isConst :
 				TypeFlags::none
@@ -161,7 +161,7 @@ struct BindingType<ValueType<ArgType>> {
 // Numeric and boolean types.
 // The static cast silences a compiler warning in Visual Studio.
 
-#define DEFINE_NATIVE_BINDING_TYPE(ArgType, checker, decode, jsClass) \
+#define DEFINE_NATIVE_BINDING_TYPE(ArgType, checker, FromType, jsClass) \
 template <> struct BindingType<ArgType> {                   \
 	typedef ArgType Type;                                   \
 	                                                        \
@@ -170,7 +170,7 @@ template <> struct BindingType<ArgType> {                   \
 	}                                                       \
 	                                                        \
 	static inline Type fromWireType(WireType arg) {         \
-		return(static_cast<Type>(arg->decode()));           \
+		return(static_cast<ArgType>(Nan::To<FromType>(arg).FromJust()));           \
 	}                                                       \
 	                                                        \
 	static inline WireType toWireType(Type arg) {           \
@@ -184,20 +184,20 @@ template <> struct BindingType<StrictType<ArgType>> : public BindingType<ArgType
 	}                                                       \
 }
 
-DEFINE_NATIVE_BINDING_TYPE(bool, IsBoolean, BooleanValue, v8::Boolean);
+DEFINE_NATIVE_BINDING_TYPE(bool, IsBoolean, bool, v8::Boolean);
 
-DEFINE_NATIVE_BINDING_TYPE(double, IsNumber, NumberValue, v8::Number);
-DEFINE_NATIVE_BINDING_TYPE(float, IsNumber, NumberValue, v8::Number);
+DEFINE_NATIVE_BINDING_TYPE(double, IsNumber, double, v8::Number);
+DEFINE_NATIVE_BINDING_TYPE(float, IsNumber, double, v8::Number);
 
-DEFINE_NATIVE_BINDING_TYPE(unsigned int, IsNumber, Uint32Value, v8::Uint32);
-DEFINE_NATIVE_BINDING_TYPE(unsigned short, IsNumber, Uint32Value, v8::Uint32);
-DEFINE_NATIVE_BINDING_TYPE(unsigned char, IsNumber, Uint32Value, v8::Uint32);
+DEFINE_NATIVE_BINDING_TYPE(unsigned int, IsNumber, unsigned int, v8::Uint32);
+DEFINE_NATIVE_BINDING_TYPE(unsigned short, IsNumber, unsigned int, v8::Uint32);
+DEFINE_NATIVE_BINDING_TYPE(unsigned char, IsNumber, unsigned int, v8::Uint32);
 
-DEFINE_NATIVE_BINDING_TYPE(signed int, IsNumber, Int32Value, v8::Int32);
-DEFINE_NATIVE_BINDING_TYPE(signed short, IsNumber, Int32Value, v8::Int32);
-DEFINE_NATIVE_BINDING_TYPE(signed char, IsNumber, Int32Value, v8::Int32);
+DEFINE_NATIVE_BINDING_TYPE(signed int, IsNumber, int, v8::Int32);
+DEFINE_NATIVE_BINDING_TYPE(signed short, IsNumber, int, v8::Int32);
+DEFINE_NATIVE_BINDING_TYPE(signed char, IsNumber, int, v8::Int32);
 
-DEFINE_NATIVE_BINDING_TYPE(char, IsNumber, Int32Value, v8::Int32);
+DEFINE_NATIVE_BINDING_TYPE(char, IsNumber, int, v8::Int32);
 
 #define DEFINE_STRING_BINDING_TYPE(ArgType)             \
 template <> struct BindingType<ArgType> {               \

--- a/include/nbind/v8/Buffer.h
+++ b/include/nbind/v8/Buffer.h
@@ -30,7 +30,7 @@ template<> struct BindingType<Buffer> {
 	}
 
 	static inline Type fromWireType(WireType arg) {
-		Buffer result(nullptr, 0, arg->ToObject());
+		Buffer result(nullptr, 0, Nan::To<v8::Object>(arg).ToLocalChecked());
 
 #		if NODE_MODULE_VERSION >= 14 // Node.js 0.12
 			if(arg->IsArrayBuffer() || arg->IsArrayBufferView()) {

--- a/include/nbind/v8/Caller.h
+++ b/include/nbind/v8/Caller.h
@@ -20,7 +20,7 @@ v8::Local<v8::Value> makeTypeError(
 	(void)args; // Silence compiler warning about unused parameter.
 
 	v8::Local<v8::Value> err = Nan::TypeError("Type mismatch");
-	v8::Local<v8::Object> errObj = err->ToObject();
+	v8::Local<v8::Object> errObj = Nan::To<v8::Object>(err).ToLocalChecked();
 	// v8::Local<v8::Array> typeArray = Nan::New<v8::Array>(count);
 	v8::Local<v8::Array> flagArray = Nan::New<v8::Array>(count);
 

--- a/include/nbind/v8/External.h
+++ b/include/nbind/v8/External.h
@@ -109,7 +109,7 @@ struct BindingType<External> {
 
 	static inline bool checkType(WireType arg) { return(arg->IsObject()); }
 
-	static inline Type fromWireType(WireType arg) { return(External(arg->ToObject())); }
+	static inline Type fromWireType(WireType arg) { return(External(Nan::To<v8::Object>(arg).ToLocalChecked())); }
 	static inline WireType toWireType(Type arg) { return(arg.getHandle()); }
 
 };

--- a/include/nbind/v8/Int64.h
+++ b/include/nbind/v8/Int64.h
@@ -11,7 +11,7 @@ template <typename ArgType>
 static ArgType int64FromWire(WireType arg, void(init)(const Nan::FunctionCallbackInfo<v8::Value> &args)) {
 	Nan::HandleScope();
 
-	auto target = arg->ToObject();
+	auto target = Nan::To<v8::Object>(arg).ToLocalChecked();
 	auto fromJS = target->Get(Nan::New<v8::String>("fromJS").ToLocalChecked());
 
 	if(!fromJS->IsFunction()) throw(std::runtime_error("Type mismatch"));
@@ -51,7 +51,7 @@ template <int size> struct Int64Converter {
 		ArgType &storage = *static_cast<ArgType *>(Nan::GetInternalFieldPointer(args.Holder(), 0));
 
 		unsigned int argc = args.Length();
-		if(argc > 0) storage = args[0]->Uint32Value();
+		if(argc > 0) storage = Nan::To<unsigned int>(args[0]).FromJust();
 
 		args.GetReturnValue().Set(Nan::Undefined());
 	}
@@ -61,8 +61,8 @@ template <int size> struct Int64Converter {
 		ArgType &storage = *static_cast<ArgType *>(Nan::GetInternalFieldPointer(args.Holder(), 0));
 
 		unsigned int argc = args.Length();
-		if(argc > 0) storage = args[0]->Uint32Value();
-		if(argc > 2 && args[2]->BooleanValue()) storage = -storage;
+		if(argc > 0) storage = Nan::To<unsigned int>(args[0]).FromJust();
+		if(argc > 2 && Nan::To<bool>(args[2]).FromJust()) storage = -storage;
 
 		args.GetReturnValue().Set(Nan::Undefined());
 	}
@@ -137,8 +137,8 @@ template<> struct Int64Converter<8> {
 		ArgType &storage = *static_cast<ArgType *>(Nan::GetInternalFieldPointer(args.Holder(), 0));
 
 		unsigned int argc = args.Length();
-		if(argc > 0) storage = args[0]->Uint32Value();
-		if(argc > 1) storage += static_cast<uint64_t>(args[1]->Uint32Value()) << 32;
+		if(argc > 0) storage = Nan::To<unsigned int>(args[0]).FromJust();
+		if(argc > 1) storage += static_cast<uint64_t>(Nan::To<unsigned int>(args[1]).FromJust()) << 32;
 
 		args.GetReturnValue().Set(Nan::Undefined());
 	}
@@ -148,9 +148,9 @@ template<> struct Int64Converter<8> {
 		ArgType &storage = *static_cast<ArgType *>(Nan::GetInternalFieldPointer(args.Holder(), 0));
 
 		unsigned int argc = args.Length();
-		if(argc > 0) storage = args[0]->Uint32Value();
-		if(argc > 1) storage += static_cast<uint64_t>(args[1]->Uint32Value()) << 32;
-		if(argc > 2 && args[2]->BooleanValue()) storage = -storage;
+		if(argc > 0) storage = Nan::To<unsigned int>(args[0]).FromJust();
+		if(argc > 1) storage += static_cast<uint64_t>(Nan::To<unsigned int>(args[1]).FromJust()) << 32;
+		if(argc > 2 && Nan::To<bool>(args[2]).FromJust()) storage = -storage;
 
 		args.GetReturnValue().Set(Nan::Undefined());
 	}
@@ -172,7 +172,7 @@ template <> struct BindingType<ArgType> {                   \
 		if(arg->IsObject()) {                               \
 			return(int64FromWire<ArgType>(arg, Int64Converter<sizeof(Type)>::decode<ArgType>)); \
 		} else {                                            \
-			return(static_cast<Type>(arg->NumberValue()));  \
+			return(static_cast<Type>(Nan::To<double>(arg).FromJust()));  \
 		}                                                   \
 	}                                                       \
 };                                                          \

--- a/include/nbind/v8/ValueObj.h
+++ b/include/nbind/v8/ValueObj.h
@@ -111,7 +111,7 @@ template <> struct BindingType<v8::Local<v8::Object>> {
 
 template <typename ArgType>
 inline ArgType BindingType<ValueType<ArgType>>::fromWireType(WireType arg) noexcept(false) {
-	auto target = arg->ToObject();
+	auto target = Nan::To<v8::Object>(arg).ToLocalChecked();
 	auto fromJS = target->Get(Nan::New<v8::String>("fromJS").ToLocalChecked());
 
 	if(!fromJS->IsFunction()) throw(std::runtime_error("Type mismatch"));

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "node-gyp": "^3.6.2",
     "tap": "^10.7.3",
     "tslint": "^5.9.1",
-    "typescript": "~2.3.4"
+    "typescript": "^3.4.3"
   }
 }

--- a/src/v8/Binding.cc
+++ b/src/v8/Binding.cc
@@ -255,7 +255,7 @@ static void initModule(Handle<Object> exports) {
 			Nan::New<v8::External>(param)
 		);
 
-		Local<v8::Function> jsFunction = functionTemplate->GetFunction();
+		Local<v8::Function> jsFunction = Nan::GetFunction(functionTemplate).ToLocalChecked();
 
 		exports->Set(
 			Nan::New<String>(func.getName()).ToLocalChecked(),

--- a/test/test.ts
+++ b/test/test.ts
@@ -366,7 +366,7 @@ test('Inheritance', function(t: any) {
 	const C = testModule.InheritanceC;
 	const D = testModule.InheritanceD;
 
-	const d = new D();
+	const d: any = new D();
 
 	t.ok(d instanceof A);
 	t.ok(d instanceof B || d instanceof C);


### PR DESCRIPTION
This PR updates nbind's codebase to support node 12. The changes are backwards compatible.

Currently, attempting to build e.g. [yoga-layout](https://github.com/facebook/yoga/tree/master/javascript) against node 12 results in various compile errors. The errors are because nbind calls v8 APIs directly rather than using nan APIs, and the v8 apis have changed significantly in node 12.